### PR TITLE
Major performance improvements, made lazy loading false by default

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -12,4 +12,14 @@ end
 vim.opt.rtp:prepend(lazypath)
 
 require("vim-options")
-require("lazy").setup("plugins")
+require("lazy").setup({
+    spec = {
+      { import = "plugins" }, -- loads all plugins in plugins/
+    },
+    defaults = {
+      lazy = false, -- plugins are not lazy loaded by default
+    },
+
+})
+
+

--- a/lua/plugins/alpha.lua
+++ b/lua/plugins/alpha.lua
@@ -1,5 +1,6 @@
 return {
   "goolord/alpha-nvim",
+  event = "VimEnter", -- load plugin after all configuration is set
   dependencies = {
     "nvim-tree/nvim-web-devicons",
   },

--- a/lua/plugins/catppuccin.lua
+++ b/lua/plugins/catppuccin.lua
@@ -1,7 +1,6 @@
 return {
   {
     "catppuccin/nvim",
-    lazy = false,
     name = "catppuccin",
     priority = 1000,
     config = function()

--- a/lua/plugins/completions.lua
+++ b/lua/plugins/completions.lua
@@ -1,9 +1,11 @@
 return {
   {
-    "hrsh7th/cmp-nvim-lsp"
+    "hrsh7th/cmp-nvim-lsp",
+    lazy = true, -- we let nvim-cmp load this for us
   },
   {
     "L3MON4D3/LuaSnip",
+    lazy = true, -- we let nvim-cmp load this too
     dependencies = {
       "saadparwaiz1/cmp_luasnip",
       "rafamadriz/friendly-snippets",
@@ -11,6 +13,7 @@ return {
   },
   {
     "hrsh7th/nvim-cmp",
+    event = "InsertEnter", -- load cmp after entering insert mode
     config = function()
       local cmp = require("cmp")
       require("luasnip.loaders.from_vscode").lazy_load()

--- a/lua/plugins/lsp-config.lua
+++ b/lua/plugins/lsp-config.lua
@@ -1,21 +1,23 @@
 return {
   {
     "williamboman/mason.nvim",
-    lazy = false,
+    cmd = "Mason", -- load mason when running :Mason command
     config = function()
       require("mason").setup()
     end,
   },
   {
     "williamboman/mason-lspconfig.nvim",
-    lazy = false,
+    event = "VeryLazy", -- load this after critical plugins
     opts = {
       auto_install = true,
     },
   },
   {
     "neovim/nvim-lspconfig",
-    lazy = false,
+    -- load lsp config when reading a buffer or creating a new one
+    event = { "BufReadPre", "BufNewFile" }, 
+
     config = function()
       local capabilities = require('cmp_nvim_lsp').default_capabilities()
 

--- a/lua/plugins/lualine.lua
+++ b/lua/plugins/lualine.lua
@@ -1,5 +1,6 @@
 return {
 	"nvim-lualine/lualine.nvim",
+    event = "VeryLazy", -- load this plugin after critical plugins
 	config = function()
 		require("lualine").setup({
 			options = {

--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -1,13 +1,13 @@
 return {
-	"nvim-neo-tree/neo-tree.nvim",
+  "nvim-neo-tree/neo-tree.nvim",
+  keys = { -- only load the plugin on these keymaps
+      { "<C-n>", "<CMD>Neotree filesystem reveal left<CR>" },
+      { "<leader>bf", "<CMD>Neotree buffers reveal float<CR>" },
+  },
 	branch = "v3.x",
 	dependencies = {
 		"nvim-lua/plenary.nvim",
 		"nvim-tree/nvim-web-devicons",
 		"MunifTanjim/nui.nvim",
 	},
-	config = function()
-		vim.keymap.set("n", "<C-n>", ":Neotree filesystem reveal left<CR>", {})
-		vim.keymap.set("n", "<leader>bf", ":Neotree buffers reveal float<CR>", {})
-	end,
 }

--- a/lua/plugins/none-ls.lua
+++ b/lua/plugins/none-ls.lua
@@ -1,5 +1,6 @@
 return {
 	"nvimtools/none-ls.nvim",
+	event = { "BufReadPre", "BufNewFile" }, -- load the plugin when entering a buffer
 	config = function()
 		local null_ls = require("null-ls")
 		null_ls.setup({

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -1,9 +1,15 @@
 return {
   {
     "nvim-telescope/telescope-ui-select.nvim",
+    lazy = true, -- we let telescope load this for us
   },
   {
     "nvim-telescope/telescope.nvim",
+    keys = { -- only load the plugin when these keys are pressed:
+        { "<C-p>", "<CMD>Telescope find_files<CR>" },
+        { "<leader>fg", "<CMD>Telescope live_grep<CR>" },
+    },
+
     tag = "0.1.5",
     dependencies = { "nvim-lua/plenary.nvim" },
     config = function()
@@ -14,10 +20,6 @@ return {
           },
         },
       })
-      local builtin = require("telescope.builtin")
-      vim.keymap.set("n", "<C-p>", builtin.find_files, {})
-      vim.keymap.set("n", "<leader>fg", builtin.live_grep, {})
-
       require("telescope").load_extension("ui-select")
     end,
   },

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -1,6 +1,7 @@
 return {
   {
     "nvim-treesitter/nvim-treesitter",
+    event = { "BufReadPre", "BufNewFile" }, -- load when a buffer is opened or created
     build = ":TSUpdate",
     config = function()
       local config = require("nvim-treesitter.configs")


### PR DESCRIPTION
By using the lazy package manager's built in features, I have improved the start-up time from **~200ms to ~17ms** (on my machine). This was achieved by loading plugins either lazily or by tweaking the plugin load order. The changes are commented and explained in the code, but just to explain briefly:

The `cmd` option only loads a plugin when a certain command is entered, not on start-up.

The `event` option only loads plugins when certain events in neovim's event loop are triggered.

The `keys` option allows you to set keymaps that actually load the plugin itself. For example, telescope is not loaded until the user executes a telescope key command. The end user doesn't notice this, and not loading a major plugin largely improves performance.

The only other change made was to make lazy loading off by default. In the config, I noticed a lot of `lazy = false`. Lazy has an option to specify the default state of lazy loading, which I have switched off by default in the `init.lua`. No longer do you need to specify when lazy loading should be false, only when it's true.

I have documented all options with comments, in hopes that anyone with the config can easily understand or have a point of reference if they are wondering what the line of code does. If anyone has any questions about these changes, feel free to let me know.👍