### PR TITLE
Add support for none-ls-extras and fix issue with eslint_d

### DIFF
--- a/lua/plugins/none-ls.lua
+++ b/lua/plugins/none-ls.lua
@@ -1,18 +1,21 @@
 return {
-	"nvimtools/none-ls.nvim",
-	config = function()
-		local null_ls = require("null-ls")
-		null_ls.setup({
-			sources = {
-				null_ls.builtins.formatting.stylua,
-				null_ls.builtins.formatting.prettier,
-				null_ls.builtins.diagnostics.erb_lint,
-				null_ls.builtins.diagnostics.eslint_d,
-				null_ls.builtins.diagnostics.rubocop,
-				null_ls.builtins.formatting.rubocop,
-			},
-		})
+  "nvimtools/none-ls.nvim",
+  dependencies = {
+    "nvimtools/none-ls-extras.nvim",
+  },
+  config = function()
+    local null_ls = require("null-ls")
+    null_ls.setup({
+      sources = {
+        null_ls.builtins.formatting.stylua,
+        null_ls.builtins.formatting.prettier,
+        null_ls.builtins.diagnostics.erb_lint,
+        require("none-ls.diagnostics.eslint_d"),
+        null_ls.builtins.diagnostics.rubocop,
+        null_ls.builtins.formatting.rubocop,
+      },
+    })
 
-		vim.keymap.set("n", "<leader>gf", vim.lsp.buf.format, {})
-	end,
+    vim.keymap.set("n", "<leader>gf", vim.lsp.buf.format, {})
+  end,
 }


### PR DESCRIPTION
This PR adds a dependency to none-ls-extras and fixes an issue that prevented eslint_d from loading in none-ls. I have tested these changes in my local environment and everything seems to work correctly. Please review these changes and let me know if there is anything that needs to be modified. Thank you!